### PR TITLE
Explicitly specify the parser to be used by BeautifulSoup

### DIFF
--- a/QuantDB/insert_symbols.py
+++ b/QuantDB/insert_symbols.py
@@ -28,7 +28,7 @@ def obtain_parse_wiki_snp500():
     response = requests.get(
         "http://en.wikipedia.org/wiki/List_of_S%26P_500_companies"
     )
-    soup = bs4.BeautifulSoup(response.text)
+    soup = bs4.BeautifulSoup(response.text, 'lxml')
 
     # This selects the first table, using CSS Selector syntax
     # and then ignores the header row ([1:])


### PR DESCRIPTION
The pull request will prevent warnings such as below

$ python -c "from insert_symbols import obtain_parse_wiki_snp500; a = obtain_parse_wiki_snp500()"
C:\ProgramData\Continuum\Anaconda\envs\py36\lib\site-packages\bs4\__init__.py:181: UserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("lxml"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

The code that caused this warning is on line 1 of the file <string>. To get rid of this warning, change code that looks like this:

 BeautifulSoup(YOUR_MARKUP})

to this:

 BeautifulSoup(YOUR_MARKUP, "lxml")

  markup_type=markup_type))
(py36)